### PR TITLE
fix: add missing semicolon

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -47,7 +47,7 @@ EXPORT(HRESULT) V2Link(iTVPFunctionExporter *exporter)
 {
 	TVPInitImportStub(exporter);
 
-	kagparserex_init()
+	kagparserex_init();
 
 	GlobalRefCountAtInit = TVPPluginGlobalRefCount;
 	return S_OK;


### PR DESCRIPTION
There was a missing semicolon in the call to `kagparserex_init` in `V2Link`. This has been fixed.